### PR TITLE
Bugfix for PostgreSQL not starting up because of incorrect server.key permissions

### DIFF
--- a/stackgres-k8s/src/operator/src/main/resources/templates/start-patroni.sh
+++ b/stackgres-k8s/src/operator/src/main/resources/templates/start-patroni.sh
@@ -374,7 +374,7 @@ mv "$PATRONI_CONFIG_FILE_PATH".tmp "$PATRONI_CONFIG_FILE_PATH"
 
 cat << EOF > "${LOCAL_BIN_PATH}/postgres"
 #!/bin/sh
-chmod 700 "$PG_DATA_PATH"
+chmod -R 700 "$PG_DATA_PATH"
 exec "$PG_BIN_PATH/postgres" "\$@"
 EOF
 chmod 755 "${LOCAL_BIN_PATH}/postgres"

--- a/stackgres-k8s/src/operator/src/main/resources/templates/start-patroni.sh
+++ b/stackgres-k8s/src/operator/src/main/resources/templates/start-patroni.sh
@@ -374,7 +374,8 @@ mv "$PATRONI_CONFIG_FILE_PATH".tmp "$PATRONI_CONFIG_FILE_PATH"
 
 cat << EOF > "${LOCAL_BIN_PATH}/postgres"
 #!/bin/sh
-chmod -R 700 "$PG_DATA_PATH"
+chmod 700 "$PG_DATA_PATH"
+chmod 700 "${PG_DATA_PATH}/server.key" # fix private key file server.key has group or world access error
 exec "$PG_BIN_PATH/postgres" "\$@"
 EOF
 chmod 755 "${LOCAL_BIN_PATH}/postgres"


### PR DESCRIPTION
Postgresql is unable to start after pod deletion (probably because fsGroup forcing incorrect permissions):

```
2025-05-08 10:13:56,203 INFO: Lock owner: db-postgresql-cluster-meta-coord-0; I am db-postgresql-cluster-meta-coord-2
2025-05-08 10:13:56,213 INFO: Local timeline=1 lsn=0/30A1D50
2025-05-08 10:13:56,249 INFO: primary_timeline=1
2025-05-08 10:13:56,249 INFO: Lock owner: db-postgresql-cluster-meta-coord-0; I am db-postgresql-cluster-meta-coord-2
2025-05-08 10:13:56,249 INFO: starting as a secondary
2025-05-08 10:13:56 UTC [136103]: db=,user=,app=,client= FATAL:  private key file "server.key" has group or world access
2025-05-08 10:13:56 UTC [136103]: db=,user=,app=,client= DETAIL:  File must have permissions u=rw (0600) or less if owned by the database user, or permissions u=rw,g=r (0640) or less if owned by root.
2025-05-08 10:13:56 UTC [136103]: db=,user=,app=,client= LOG:  database system is shut down
2025-05-08 10:13:56,587 INFO: postmaster pid=136103
2025-05-08 10:14:01,386 INFO: establishing a new patroni heartbeat connection to postgres
2025-05-08 10:14:03,126 INFO: establishing a new patroni heartbeat connection to postgres
2025-05-08 10:14:03,127 WARNING: Retry got exception: connection problems
/var/run/postgresql:5432 - no response
2025-05-08 10:14:06,183 INFO: Lock owner: db-postgresql-cluster-meta-coord-0; I am db-postgresql-cluster-meta-coord-2
2025-05-08 10:14:06,183 INFO: failed to start postgres
```

The quick fix is to force correct permissions beforehand.