### PR TITLE
Update the high availability docs to use the correct label

### DIFF
--- a/doc/content/en/04-administration-guide/09-high-availability/_index.md
+++ b/doc/content/en/04-administration-guide/09-high-availability/_index.md
@@ -36,7 +36,7 @@ There are two different ways to accomplish this. The first one is with the `kube
 To identify the primary node:
 
 ```
-$ kubectl get pods -n default -l app=StackGresCluster -l role=master
+$ kubectl get pods -n default -l app=StackGresCluster -l role=primary
 NAME          READY   STATUS    RESTARTS   AGE
 stackgres-0   5/5     Running   0          165m
 ```


### PR DESCRIPTION
Minor doc change I noticed while trying to follow the docs when setting up HA for myself.